### PR TITLE
Escape source URLs, add Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app

--- a/app.py
+++ b/app.py
@@ -125,7 +125,7 @@ def document(city):
 
     response = make_response(output.getvalue())
     response.headers['Content-Type'] = content_type
-    response.headers['Source-URL'] = source_url
+    response.headers['Source-URL'] = urllib.parse.quote(source_url, safe=":/")
 
     if 'pdf' not in content_type:
         response.headers['Content-Disposition'] = 'attachment;filename="{}"'.format(filename)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2.4'
+
+services:
+  app:
+    image: property-image-cache
+    build: .
+    container_name: property-image-cache
+    stdin_open: true
+    tty: true
+    ports:
+      - 5001:5000
+    volumes:
+      - .:/app
+    command: python app.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-Flask==0.11
+Flask==1.0
 requests==2.7.0
 boto==2.38.0
 flask_cors==2.1.2
 sentry-sdk[flask]==0.16.1
 gunicorn
+Jinja2<=3.0.0
+itsdangerous<=2.0.1


### PR DESCRIPTION
## Description

Sometimes, source file URLs contain Unicode characters, causing the `python.http` module to complain that they can't be properly encoded. Only ASCII characters are guaranteed to work as header values: https://stackoverflow.com/questions/4400678/what-character-encoding-should-i-use-for-a-http-header

This PR escapes all characters in a document source URL apart from the usual `/` and `:` in order to ensure that it can be properly encoded for headers, while still resolving to the correct resource.

It also adds a minimal Docker setup to run this app, since it depends on Python  <= 3.8, which is not what most folks have on their machines in 2023.

Connects https://github.com/Metro-Records/la-metro-councilmatic/issues/952

### Testing instructions

- Tested locally by decrypting the app secrets (`blackbox_cat configs/app_config.py.gpg > app_config.py`), running the app (`docker-compose up`), and confirming that [the problematic URL](http://localhost:5001/lametro/document/?document_url=https%3A%2F%2Fmetro.legistar1.com%2Fmetro%2Fmeetings%2F2023%2F3%2F2524_A_Independent_Citizen%25E2%2580%2599s_Advisory_and_Oversight_Committee_23-03-13_Agenda.pdf&filename=agenda) now resolves as expected